### PR TITLE
Fix useless assignment to local variable

### DIFF
--- a/bin/purdy.js
+++ b/bin/purdy.js
@@ -133,8 +133,6 @@ internals.parse = function (str) {
 
 internals.main = function () {
 
-    let stream = process.stdin;
-
     internals.args = internals.initalizeBossy();
 
     try {


### PR DESCRIPTION
The assignment to the `stream` variable whose value is always overwritten has no effect.